### PR TITLE
CodecJson examples were defined with DecodeJson

### DIFF
--- a/src/main/scala/argonaut/doc/CodecJsonDefaultExample.scala
+++ b/src/main/scala/argonaut/doc/CodecJsonDefaultExample.scala
@@ -8,13 +8,13 @@ object CodecJsonDefaultExample extends App {
 
   // Default CodecJson instance for case classes.
 
-  implicit def PersonCodecJson: DecodeJson[Person] =
+  implicit def PersonCodecJson: CodecJson[Person] =
     casecodec2(Person.apply, Person.unapply)("name", "age")
 
   // Note that casecodec2 makes assumptions about the unapply
   // method (namely that it will always return Some), for a
   // an exmplic version of this see:
 
-  def ExplicitPersonCodecJson: DecodeJson[Person] =
+  def ExplicitPersonCodecJson: CodecJson[Person] =
     codec2(Person.apply, (Person.unapply _) andThen (_.get))("name", "age")
 }

--- a/src/main/scala/argonaut/doc/CodecJsonExample.scala
+++ b/src/main/scala/argonaut/doc/CodecJsonExample.scala
@@ -8,7 +8,7 @@ object CodecJsonExample extends App {
 
   // Explicit CodecJson instance.
 
-  implicit def PersonCodecJson: DecodeJson[Person] =
+  implicit def PersonCodecJson: CodecJson[Person] =
     CodecJson(
       (p: Person) =>
         ("name" := p.name) ->:


### PR DESCRIPTION
The defintions of the CodecJson examples were defined
using `DecodeJson[Person]` instead of `CodecJson[Person]` this was
somewhat misleading. At least for me. ;-)
